### PR TITLE
fix(runtime): 统一macOS资源路径为小写格式

### DIFF
--- a/src/main/kotlin/runtime/RuntimeStore.kt
+++ b/src/main/kotlin/runtime/RuntimeStore.kt
@@ -69,7 +69,7 @@ class AdbStore(runtimeDir: File) : Runtime() {
     val resourceName by lazy {
         val hostName = when {
             hostOs.isWindows -> "windows"
-            hostOs.isMacOS -> "macOS"
+            hostOs.isMacOS -> "macos"
             else -> "linux"
         }
         "files/$hostName/adb.zip"


### PR DESCRIPTION
将macOS平台adb.zip资源路径从"macOS"改为"macos"以保持命名一致性，因为Compose Resources好像并不支持大写字母