### PR TITLE
opt(frame): border shadow

### DIFF
--- a/src/main/kotlin/view/components/CustomWindowFrame.kt
+++ b/src/main/kotlin/view/components/CustomWindowFrame.kt
@@ -39,7 +39,10 @@ fun FrameWindowScope.CustomWindowFrame(
     var updateInfo by remember { mutableStateOf<UpdateInfo?>(null) }
     
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(4.dp),
+        shadowElevation = 4.dp,
         color = MaterialTheme.colorScheme.background
     ) {
         Column(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
给自定义窗口添加了一个阴影描边，避免在浅色背景下看不清

对比：

![image](https://github.com/user-attachments/assets/7bf3342d-fb2a-42b3-a9ce-bae39c65ef17)

![image](https://github.com/user-attachments/assets/96a83a4b-573e-44bd-bc28-fff363a76bc8)
